### PR TITLE
Added  a `quote_color` options to the config

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -44,6 +44,10 @@ pub struct Cli {
     #[arg(long)]
     pub rounded_border: Option<bool>,
 
+    // Border color (hex like #888888 or named)
+    #[arg(long)]
+    pub border_color: Option<String>,
+
     // Show quote source
     #[arg(long)]
     pub source: Option<bool>,

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -28,6 +28,10 @@ pub struct Cli {
     #[arg(long)]
     pub translation_color: Option<String>,
 
+    // Quote color (hex like #888888 or named)
+    #[arg(long)]
+    pub quote_color: Option<String>,
+
     // Make Japanese text bold
     #[arg(long)]
     pub bold: Option<bool>,

--- a/src/config.rs
+++ b/src/config.rs
@@ -28,6 +28,7 @@ pub struct DisplayConfig {
     pub bold: Option<bool>,
     pub border: Option<bool>,
     pub rounded_border: Option<bool>,
+    pub border_color: Option<String>,
     pub source: Option<bool>,
     pub modes: Option<Vec<PathBuf>>,
     pub seed: Option<u64>,
@@ -46,6 +47,7 @@ pub struct RuntimeConfig {
     pub bold: bool,
     pub border: bool,
     pub rounded_border: bool,
+    pub border_color: String,
     pub source: bool,
     pub modes: Vec<PathBuf>,
     pub seed: u64,
@@ -61,6 +63,7 @@ impl Default for RuntimeConfig {
             show_translation: TranslationMode::English,
             translation_color: "dim".to_string(),
             quote_color: "white".to_string(),
+            border_color: "white".to_string(),
             font_size: "medium".to_string(),
             bold: true,
             border: true,
@@ -146,6 +149,9 @@ pub fn make_runtime_config(
             if let Some(b) = d.rounded_border {
                 r.rounded_border = b;
             }
+            if let Some(bc) = d.border_color {
+                r.border_color = bc;
+            }
             if let Some(b) = d.source {
                 r.source = b;
             }
@@ -196,6 +202,9 @@ pub fn make_runtime_config(
     if let Some(b) = cli.rounded_border {
         r.rounded_border = b;
     }
+    if let Some(bc) = &cli.border_color {
+        r.border_color = bc.clone();
+}
     if let Some(b) = cli.source {
         r.source = b;
     }

--- a/src/config.rs
+++ b/src/config.rs
@@ -23,6 +23,7 @@ pub struct DisplayConfig {
     pub width: Option<usize>,
     pub show_translation: Option<TranslationMode>,
     pub translation_color: Option<String>,
+    pub quote_color: Option<String>,
     pub font_size: Option<String>,
     pub bold: Option<bool>,
     pub border: Option<bool>,
@@ -40,6 +41,7 @@ pub struct RuntimeConfig {
     pub width: usize,
     pub show_translation: TranslationMode,
     pub translation_color: String,
+    pub quote_color: String,
     pub font_size: String,
     pub bold: bool,
     pub border: bool,
@@ -58,6 +60,7 @@ impl Default for RuntimeConfig {
             width: 0, // 0 = automatic
             show_translation: TranslationMode::English,
             translation_color: "dim".to_string(),
+            quote_color: "white".to_string(),
             font_size: "medium".to_string(),
             bold: true,
             border: true,
@@ -128,6 +131,9 @@ pub fn make_runtime_config(
             if let Some(tc) = d.translation_color {
                 r.translation_color = tc;
             }
+            if let Some(qc) = d.quote_color {
+                r.quote_color = qc;
+            }
             if let Some(fs) = d.font_size {
                 r.font_size = fs;
             }
@@ -177,6 +183,9 @@ pub fn make_runtime_config(
 
     if let Some(tc) = &cli.translation_color {
         r.translation_color = tc.clone();
+    }
+    if let Some(qc) = &cli.quote_color {
+        r.quote_color = qc.clone();
     }
     if let Some(b) = cli.bold {
         r.bold = b;

--- a/src/display.rs
+++ b/src/display.rs
@@ -120,13 +120,15 @@ fn align_in_box(line: &str, inner_width: usize, centered: bool) -> String {
 }
 
 // Create an empty line inside the box (used for spacing).
-fn blank_line(inner_width: usize, horizontal_padding: usize, border: bool) -> String {
+fn blank_line(inner_width: usize, horizontal_padding: usize, border: bool, border_color: &Style) -> String {
     if border {
         format!(
-            "│{}{}{}│",
+            "{}{}{}{}{}",
+            border_color.apply_to("│"),
             " ".repeat(horizontal_padding),
             " ".repeat(inner_width),
-            " ".repeat(horizontal_padding)
+            " ".repeat(horizontal_padding),
+            border_color.apply_to("│")
         )
     } else {
         " ".repeat(horizontal_padding + inner_width)
@@ -141,16 +143,19 @@ fn print_block(
     border: bool,
     box_width: usize,
     centered: bool,
+    border_color: &Style, // <-- add this parameter
 ) {
     for line in lines {
         for wline in wrap(line, inner_width) {
             let content = align_in_box(wline.as_ref(), inner_width, centered);
             let line = if border {
                 format!(
-                    "│{}{}{}│",
+                    "{}{}{}{}{}",
+                    border_color.apply_to("│"),
                     " ".repeat(horizontal_padding),
                     style.apply_to(content),
-                    " ".repeat(horizontal_padding)
+                    " ".repeat(horizontal_padding),
+                    border_color.apply_to("│")
                 )
             } else {
                 format!(
@@ -172,6 +177,7 @@ fn print_boxed(
     width: usize,
     border: bool,
     rounded_border: bool,
+    border_color: Style,
     translation: Option<&str>,
     show_translation: bool,
     translation_style: Style,
@@ -229,7 +235,7 @@ fn print_boxed(
             horiz.repeat(inner_width + horizontal_padding * 2),
             top_right
         );
-        println!("{}", pad_to_center(&line, box_width, centered));
+        println!("{}", border_color.apply_to(pad_to_center(&line, box_width, centered)));
     }
 
     // Vertical padding (top)
@@ -237,7 +243,7 @@ fn print_boxed(
         println!(
             "{}",
             pad_to_center(
-                &blank_line(inner_width, horizontal_padding, border),
+                &blank_line(inner_width, horizontal_padding, border, &border_color),
                 box_width,
                 centered
             )
@@ -253,6 +259,7 @@ fn print_boxed(
         border,
         box_width,
         centered,
+        &border_color
     );
 
     // Translation
@@ -261,7 +268,7 @@ fn print_boxed(
             println!(
                 "{}",
                 pad_to_center(
-                    &blank_line(inner_width, horizontal_padding, border),
+                    &blank_line(inner_width, horizontal_padding, border, &border_color),
                     box_width,
                     centered
                 )
@@ -274,6 +281,7 @@ fn print_boxed(
                 border,
                 box_width,
                 centered,
+                &border_color
             );
         }
     }
@@ -284,7 +292,7 @@ fn print_boxed(
             println!(
                 "{}",
                 pad_to_center(
-                    &blank_line(inner_width, horizontal_padding, border),
+                    &blank_line(inner_width, horizontal_padding, border, &border_color),
                     box_width,
                     centered
                 )
@@ -308,6 +316,7 @@ fn print_boxed(
                 border,
                 box_width,
                 centered,
+                &border_color
             );
         }
     }
@@ -317,7 +326,7 @@ fn print_boxed(
         println!(
             "{}",
             pad_to_center(
-                &blank_line(inner_width, horizontal_padding, border),
+                &blank_line(inner_width, horizontal_padding, border, &border_color),
                 box_width,
                 centered
             )
@@ -332,7 +341,7 @@ fn print_boxed(
             horiz.repeat(inner_width + horizontal_padding * 2),
             bottom_right
         );
-        println!("{}", pad_to_center(&line, box_width, centered));
+        println!("{}", border_color.apply_to(pad_to_center(&line, box_width, centered)));
     }
 }
 
@@ -423,6 +432,8 @@ pub fn render(runtime: &RuntimeConfig, cli: &crate::cli::Cli) {
         color_from_hex(&runtime.quote_color)
     };
 
+    let border_color = color_from_hex(&runtime.border_color);
+
     print_boxed(
         jap_lines,
         jap_style,
@@ -431,6 +442,7 @@ pub fn render(runtime: &RuntimeConfig, cli: &crate::cli::Cli) {
         runtime.width,
         runtime.border,
         runtime.rounded_border,
+        border_color,
         translation,
         show_translation,
         translation_style,

--- a/src/display.rs
+++ b/src/display.rs
@@ -166,7 +166,7 @@ fn print_block(
 
 fn print_boxed(
     text_lines: Vec<String>,
-    bold: bool,
+    jap_style: Style,
     horizontal_padding: usize,
     vertical_padding: usize,
     width: usize,
@@ -208,11 +208,11 @@ fn print_boxed(
     };
 
     let box_width = inner_width + horizontal_padding * 2 + if border { 2 } else { 0 };
-    let jap_style = if bold {
-        Style::new().bold()
-    } else {
-        Style::new()
-    };
+    // let jap_style = if bold {
+    //     Style::new().bold()
+    // } else {
+    //     Style::new()
+    // };
 
     let (top_left, top_right, bottom_left, bottom_right) = if rounded_border {
         ('╭', '╮', '╰', '╯')
@@ -417,9 +417,15 @@ pub fn render(runtime: &RuntimeConfig, cli: &crate::cli::Cli) {
         crate::config::TranslationMode::Romaji => (quote.romaji.as_deref(), quote.romaji.is_some()),
     };
 
+    let jap_style = if runtime.bold {
+        color_from_hex(&runtime.quote_color).bold()
+    } else {
+        color_from_hex(&runtime.quote_color)
+    };
+
     print_boxed(
         jap_lines,
-        runtime.bold,
+        jap_style,
         runtime.horizontal_padding,
         runtime.vertical_padding,
         runtime.width,


### PR DESCRIPTION
Hi! 
Found your program on reddit. First of all, I love it! however I wanted to change the color of the quote to fit my color palette. I added a `quote_color` option to the config. Defaults to white, works like your `translation_color` option.

Might try and do that for border colors aswell later.

<img width="615" height="226" alt="image" src="https://github.com/user-attachments/assets/2bfef3d8-428b-4884-b7f4-e0f282bddbf6" />

```toml
[display]
horizontal_padding = 3
vertical_padding = 1
width = 50
show_translation = "english"
translation_color = "#f5bdb0"
quote_color = "#a3be8c"
font_size = "medium"
bold = true
border = true
rounded_border = true
source = true
modes = ["proverb", "anime", "haiku"]
seed = 0
centered = true
```