### PR TITLE
Anki Integration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -53,6 +53,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
 name = "bitflags"
 version = "2.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -168,6 +174,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bd0c93bb4b0c6d9b77f4435b0ae98c24d17f1c45b2ff844c6151a07256ca923b"
 
 [[package]]
+name = "displaydoc"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "encode_unicode"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -178,6 +195,15 @@ name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
+name = "form_urlencoded"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
+dependencies = [
+ "percent-encoding",
+]
 
 [[package]]
 name = "getrandom"
@@ -215,6 +241,108 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
+name = "icu_collections"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c6b649701667bbe825c3b7e6388cb521c23d88644678e83c0c4d0a621a34b43"
+dependencies = [
+ "displaydoc",
+ "potential_utf",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locale_core"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edba7861004dd3714265b4db54a3c390e880ab658fec5f7db895fae2046b5bb6"
+dependencies = [
+ "displaydoc",
+ "litemap",
+ "tinystr",
+ "writeable",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f6c8828b67bf8908d82127b2054ea1b4427ff0230ee9141c54251934ab1b599"
+dependencies = [
+ "icu_collections",
+ "icu_normalizer_data",
+ "icu_properties",
+ "icu_provider",
+ "smallvec",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer_data"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7aedcccd01fc5fe81e6b489c15b247b8b0690feb23304303a9e560f37efc560a"
+
+[[package]]
+name = "icu_properties"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "020bfc02fe870ec3a66d93e677ccca0562506e5872c650f893269e08615d74ec"
+dependencies = [
+ "icu_collections",
+ "icu_locale_core",
+ "icu_properties_data",
+ "icu_provider",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_properties_data"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "616c294cf8d725c6afcd8f55abc17c56464ef6211f9ed59cccffe534129c77af"
+
+[[package]]
+name = "icu_provider"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85962cf0ce02e1e0a629cc34e7ca3e373ce20dda4c4d7294bbd0bf1fdb59e614"
+dependencies = [
+ "displaydoc",
+ "icu_locale_core",
+ "writeable",
+ "yoke",
+ "zerofrom",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "idna"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
+dependencies = [
+ "idna_adapter",
+ "smallvec",
+ "utf8_iter",
+]
+
+[[package]]
+name = "idna_adapter"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
+dependencies = [
+ "icu_normalizer",
+ "icu_properties",
+]
+
+[[package]]
 name = "indexmap"
 version = "2.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -231,6 +359,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
 
 [[package]]
+name = "itoa"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
+
+[[package]]
 name = "kotofetch"
 version = "0.2.18"
 dependencies = [
@@ -240,10 +374,12 @@ dependencies = [
  "dirs",
  "rand",
  "serde",
+ "serde_json",
  "term_size",
  "textwrap",
  "toml",
  "unicode-width",
+ "ureq",
 ]
 
 [[package]]
@@ -261,6 +397,24 @@ dependencies = [
  "bitflags",
  "libc",
 ]
+
+[[package]]
+name = "litemap"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
+
+[[package]]
+name = "log"
+version = "0.4.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+
+[[package]]
+name = "memchr"
+version = "2.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "nix"
@@ -291,6 +445,21 @@ name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
+name = "percent-encoding"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
+name = "potential_utf"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b73949432f5e2a09657003c25bca5e19a0e9c84f8058ca374f49e0ebe605af77"
+dependencies = [
+ "zerovec",
+]
 
 [[package]]
 name = "ppv-lite86"
@@ -396,6 +565,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_json"
+version = "1.0.149"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
+dependencies = [
+ "itoa",
+ "memchr",
+ "serde",
+ "serde_core",
+ "zmij",
+]
+
+[[package]]
 name = "serde_spanned"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -405,10 +587,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "smallvec"
+version = "1.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+
+[[package]]
 name = "smawk"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7c388c1b5e93756d0c740965c41e8822f866621d41acbdf6336a6a168f8840c"
+
+[[package]]
+name = "stable_deref_trait"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "strsim"
@@ -425,6 +619,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "synstructure"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -466,6 +671,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "tinystr"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42d3e9c45c09de15d06dd8acf5f4e0e399e85927b7f00711024eb7ae10fa4869"
+dependencies = [
+ "displaydoc",
+ "zerovec",
 ]
 
 [[package]]
@@ -524,6 +739,38 @@ name = "unicode-width"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a1a07cc7db3810833284e8d372ccdc6da29741639ecc70c9ec107df0fa6154c"
+
+[[package]]
+name = "ureq"
+version = "2.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02d1a66277ed75f640d608235660df48c8e3c19f3b4edb6a263315626cc3c01d"
+dependencies = [
+ "base64",
+ "log",
+ "once_cell",
+ "serde",
+ "serde_json",
+ "url",
+]
+
+[[package]]
+name = "url"
+version = "2.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "percent-encoding",
+ "serde",
+]
+
+[[package]]
+name = "utf8_iter"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "utf8parse"
@@ -685,6 +932,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"
 
 [[package]]
+name = "writeable"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
+
+[[package]]
+name = "yoke"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72d6e5c6afb84d73944e5cedb052c4680d5657337201555f9f2a16b7406d4954"
+dependencies = [
+ "stable_deref_trait",
+ "yoke-derive",
+ "zerofrom",
+]
+
+[[package]]
+name = "yoke-derive"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
 name = "zerocopy"
 version = "0.8.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -703,3 +979,63 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "zerofrom"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69faa1f2a1ea75661980b013019ed6687ed0e83d069bc1114e2cc74c6c04c4df"
+dependencies = [
+ "zerofrom-derive",
+]
+
+[[package]]
+name = "zerofrom-derive"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
+name = "zerotrie"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a59c17a5562d507e4b54960e8569ebee33bee890c70aa3fe7b97e85a9fd7851"
+dependencies = [
+ "displaydoc",
+ "yoke",
+ "zerofrom",
+]
+
+[[package]]
+name = "zerovec"
+version = "0.11.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c28719294829477f525be0186d13efa9a3c602f7ec202ca9e353d310fb9a002"
+dependencies = [
+ "yoke",
+ "zerofrom",
+ "zerovec-derive",
+]
+
+[[package]]
+name = "zerovec-derive"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "zmij"
+version = "1.0.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -65,6 +65,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2261d10cca569e4643e526d8dc2e62e433cc8aba21ab764233731f8d369bf394"
 
 [[package]]
+name = "bytes"
+version = "1.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
+
+[[package]]
 name = "cfg-if"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -136,6 +142,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "cookie"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ddef33a339a91ea89fb53151bd0a4689cfce27055c291dfa69945475d22c747"
+dependencies = [
+ "percent-encoding",
+ "time",
+ "version_check",
+]
+
+[[package]]
+name = "cookie_store"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15b2c103cf610ec6cae3da84a766285b42fd16aad564758459e6ecf128c75206"
+dependencies = [
+ "cookie",
+ "document-features",
+ "idna",
+ "indexmap",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "time",
+ "url",
+]
+
+[[package]]
 name = "ctrlc"
 version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -144,6 +179,15 @@ dependencies = [
  "dispatch",
  "nix",
  "windows-sys 0.61.0",
+]
+
+[[package]]
+name = "deranged"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
+dependencies = [
+ "powerfmt",
 ]
 
 [[package]]
@@ -182,6 +226,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "document-features"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4b8a88685455ed29a21542a33abd9cb6510b6b129abadabdcef0f4c55bc8f61"
+dependencies = [
+ "litrs",
 ]
 
 [[package]]
@@ -239,6 +292,22 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "http"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
+dependencies = [
+ "bytes",
+ "itoa",
+]
+
+[[package]]
+name = "httparse"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
 name = "icu_collections"
@@ -405,6 +474,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
+name = "litrs"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092"
+
+[[package]]
 name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -427,6 +502,12 @@ dependencies = [
  "cfg_aliases",
  "libc",
 ]
+
+[[package]]
+name = "num-conv"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
 
 [[package]]
 name = "once_cell"
@@ -460,6 +541,12 @@ checksum = "b73949432f5e2a09657003c25bca5e19a0e9c84f8058ca374f49e0ebe605af77"
 dependencies = [
  "zerovec",
 ]
+
+[[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "ppv-lite86"
@@ -674,6 +761,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "time"
+version = "0.3.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
+dependencies = [
+ "deranged",
+ "itoa",
+ "num-conv",
+ "powerfmt",
+ "serde_core",
+ "time-core",
+ "time-macros",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
+
+[[package]]
+name = "time-macros"
+version = "0.2.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
+dependencies = [
+ "num-conv",
+ "time-core",
+]
+
+[[package]]
 name = "tinystr"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -742,16 +860,30 @@ checksum = "4a1a07cc7db3810833284e8d372ccdc6da29741639ecc70c9ec107df0fa6154c"
 
 [[package]]
 name = "ureq"
-version = "2.12.1"
+version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02d1a66277ed75f640d608235660df48c8e3c19f3b4edb6a263315626cc3c01d"
+checksum = "dea7109cdcd5864d4eeb1b58a1648dc9bf520360d7af16ec26d0a9354bafcfc0"
 dependencies = [
  "base64",
+ "cookie_store",
  "log",
- "once_cell",
+ "percent-encoding",
  "serde",
  "serde_json",
- "url",
+ "ureq-proto",
+ "utf8-zero",
+]
+
+[[package]]
+name = "ureq-proto"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e994ba84b0bd1b1b0cf92878b7ef898a5c1760108fe7b6010327e274917a808c"
+dependencies = [
+ "base64",
+ "http",
+ "httparse",
+ "log",
 ]
 
 [[package]]
@@ -767,6 +899,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "utf8-zero"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8c0a043c9540bae7c578c88f91dda8bd82e59ae27c21baca69c8b191aaf5a6e"
+
+[[package]]
 name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -777,6 +915,12 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "wasi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,3 +15,5 @@ term_size = "0.3.2"
 textwrap = "0.16.2"
 toml = "0.9.5"
 unicode-width = "0.2.1"
+ureq = { version = "2", default-features = false, features = ["json"] }
+serde_json = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,5 +15,5 @@ term_size = "0.3.2"
 textwrap = "0.16.2"
 toml = "0.9.5"
 unicode-width = "0.2.1"
-ureq = { version = "2", default-features = false, features = ["json"] }
+ureq = { version = "3.3.0", default-features = false, features = ["json"] }
 serde_json = "1"

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@
 - [Requirements](#requirements)
 - [Configuration](#configuration)
 - [Usage](#usage)
+- [Importing Anki decks](#importing-anki-decks)
 - [Contributing](#contributing)
 
 ## Installation
@@ -145,6 +146,37 @@ centered = true
 dynamic = false
 ```
 
+### Importing Anki decks
+
+You can import your Anki decks as kotofetch quote files using the **AnkiConnect** plugin.
+
+**Requirements:**
+1. Anki desktop must be running.
+2. AnkiConnect must be installed (plugin code: `2055492159`).
+
+**Interactive import:**
+```bash
+kotofetch init anki
+```
+This connects to `http://localhost:8765`, shows your available decks, and walks you through mapping note fields (japanese text, translation, furigana reading) interactively.
+
+**Non-interactive import (for scripting):**
+```bash
+kotofetch init anki \
+  --deck "Core 2k" \
+  --japanese-field Expression \
+  --translation-field Meaning \
+  --furigana-field Reading \
+  --yes
+```
+
+Each imported deck is saved as `~/.config/kotofetch/quotes/<deck-name>.toml`. After importing, use it with:
+```bash
+kotofetch --modes core-2k
+```
+
+**Furigana support:** if your note's japanese field contains Anki's native furigana syntax (`食[た]べる`), it is automatically converted to kotofetch's inline format (`食(た)べる`). If the japanese field has no readings, the furigana field is used as a fallback. HTML ruby tags (`<ruby>/<rt>`) are also converted.
+
 ### Custom quotes
 Built-in quotes are embedded in the binary. To add your own quotes, create:
 ```bash
@@ -191,13 +223,6 @@ kotofetch --modes anime,mycustomquotes  # display quotes from specific files
 | `english` | Shows English translation below Japanese |
 | `romaji` | Shows romaji (romanized Japanese) below Japanese |
 | `furigana` | Shows furigana readings below kanji (if available) |
-
-**Furigana Example:**
-```
-井の中の蛙大海を知らず
-い   なか  かわず たいかい   し
- — 井の中の蛙大海を知らず
-```
 
 Furigana displays readings centered below their kanji, supporting both single-kanji annotations (`知(し)`) and compound words (`大海(たいかい)`). Only quotes that include inline ruby markup in their `japanese` field will show furigana readings.
 

--- a/README.md
+++ b/README.md
@@ -162,17 +162,18 @@ This connects to `http://localhost:8765`, shows your available decks, and walks 
 
 **Non-interactive import (for scripting):**
 ```bash
-kotofetch init anki \
+kotofetch init  w \
   --deck "Core 2k" \
   --japanese-field Expression \
   --translation-field Meaning \
   --furigana-field Reading \
+  --romaji-field Romaji \
   --yes
 ```
 
 Each imported deck is saved as `~/.config/kotofetch/quotes/<deck-name>.toml`. After importing, use it with:
 ```bash
-kotofetch --modes core-2k
+kotofetch --modes <deck-name>
 ```
 
 **Furigana support:** if your note's japanese field contains Anki's native furigana syntax (`食[た]べる`), it is automatically converted to kotofetch's inline format (`食(た)べる`). If the japanese field has no readings, the furigana field is used as a fallback. HTML ruby tags (`<ruby>/<rt>`) are also converted.

--- a/src/anki.rs
+++ b/src/anki.rs
@@ -1,0 +1,702 @@
+use crate::cli::AnkiArgs;
+use dirs::config_dir;
+use serde_json::{Value, json};
+use std::collections::HashMap;
+use std::fs;
+use std::io::{self, BufRead, Write};
+use std::path::PathBuf;
+
+type Result<T> = std::result::Result<T, Box<dyn std::error::Error>>;
+
+// -- AnkiConnect client
+
+struct AnkiClient {
+    url: String,
+}
+
+impl AnkiClient {
+    fn new(url: &str) -> Self {
+        Self {
+            url: url.to_string(),
+        }
+    }
+
+    fn invoke(&self, action: &str, params: Value) -> Result<Value> {
+        let body = json!({
+            "action": action,
+            "version": 6,
+            "params": params,
+        });
+        let response = ureq::post(&self.url)
+            .send_json(body)
+            .map_err(|e| format!("Could not reach AnkiConnect at {}: {e}", self.url))?;
+        let json: Value = response
+            .into_json()
+            .map_err(|e| format!("Failed to parse AnkiConnect response: {e}"))?;
+
+        if let Some(err) = json["error"].as_str().filter(|s| !s.is_empty()) {
+            return Err(format!("AnkiConnect error: {err}").into());
+        }
+        Ok(json["result"].clone())
+    }
+
+    fn deck_names(&self) -> Result<Vec<String>> {
+        let result = self.invoke("deckNames", json!({}))?;
+        let names = result
+            .as_array()
+            .ok_or("expected array of deck names")?
+            .iter()
+            .filter_map(|v| v.as_str().map(|s| s.to_string()))
+            .collect();
+        Ok(names)
+    }
+
+    fn find_notes(&self, deck: &str) -> Result<Vec<u64>> {
+        let result = self.invoke(
+            "findNotes",
+            json!({ "query": format!("deck:\"{}\"", deck) }),
+        )?;
+        let ids = result
+            .as_array()
+            .ok_or("expected array of note IDs")?
+            .iter()
+            .filter_map(|v| v.as_u64())
+            .collect();
+        Ok(ids)
+    }
+
+    fn notes_info(&self, ids: &[u64]) -> Result<Vec<AnkiNote>> {
+        let mut all = Vec::new();
+        let chunks: Vec<&[u64]> = ids.chunks(500).collect();
+        let multi = chunks.len() > 1;
+        for (i, chunk) in chunks.iter().enumerate() {
+            if multi {
+                print!(
+                    "\r  Fetching notes {}/{}...",
+                    (i + 1) * chunk.len(),
+                    ids.len()
+                );
+                io::stdout().flush().ok();
+            }
+            let result = self.invoke("notesInfo", json!({ "notes": chunk }))?;
+            if let Some(arr) = result.as_array() {
+                for val in arr {
+                    if let Some(note) = parse_anki_note(val) {
+                        all.push(note);
+                    }
+                }
+            }
+        }
+        if multi {
+            println!();
+        }
+        Ok(all)
+    }
+}
+
+struct AnkiNote {
+    fields: HashMap<String, String>,
+    field_order: Vec<String>,
+}
+
+fn parse_anki_note(val: &Value) -> Option<AnkiNote> {
+    let fields_obj = val["fields"].as_object()?;
+    let mut fields = HashMap::new();
+    let mut ordered: Vec<(String, usize)> = Vec::new();
+    for (name, fv) in fields_obj {
+        let value = fv["value"].as_str().unwrap_or("").to_string();
+        let order = fv["order"].as_u64().unwrap_or(0) as usize;
+        fields.insert(name.clone(), value);
+        ordered.push((name.clone(), order));
+    }
+    ordered.sort_by_key(|(_, o)| *o);
+    Some(AnkiNote {
+        fields,
+        field_order: ordered.into_iter().map(|(n, _)| n).collect(),
+    })
+}
+
+// -- Field cleaning
+
+fn remove_sound_markers(s: &str) -> String {
+    let mut result = String::new();
+    let mut rest = s;
+    while let Some(start) = rest.find("[sound:") {
+        result.push_str(&rest[..start]);
+        match rest[start..].find(']') {
+            Some(end) => rest = &rest[start + end + 1..],
+            None => {
+                result.push_str(&rest[start..]);
+                return result;
+            }
+        }
+    }
+    result.push_str(rest);
+    result
+}
+
+fn convert_html_ruby(s: &str) -> String {
+    // <ruby>base<rt>reading</rt></ruby> or <ruby><rb>base</rb><rt>reading</rt></ruby>
+    // -> base(reading)
+    let mut result = String::new();
+    let lower = s.to_lowercase();
+    let mut pos = 0;
+
+    while pos < s.len() {
+        match lower[pos..].find("<ruby") {
+            None => {
+                result.push_str(&s[pos..]);
+                break;
+            }
+            Some(rel) => {
+                let abs = pos + rel;
+                result.push_str(&s[pos..abs]);
+                match s[abs..].find('>') {
+                    None => {
+                        result.push_str(&s[abs..]);
+                        break;
+                    }
+                    Some(tag_end) => {
+                        let inner_start = abs + tag_end + 1;
+                        let lower_from = inner_start.min(lower.len());
+                        match lower[lower_from..].find("</ruby>") {
+                            None => {
+                                pos = inner_start;
+                            }
+                            Some(ruby_end_rel) => {
+                                let inner = &s[inner_start..inner_start + ruby_end_rel];
+                                result.push_str(&extract_ruby_content(inner));
+                                pos = inner_start + ruby_end_rel + "</ruby>".len();
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+    result
+}
+
+fn extract_ruby_content(inner: &str) -> String {
+    let lower = inner.to_lowercase();
+
+    let base = if let (Some(s), Some(e)) = (lower.find("<rb>"), lower.find("</rb>")) {
+        &inner[s + 4..e]
+    } else {
+        let rt_pos = lower.find("<rt>").unwrap_or(inner.len());
+        &inner[..rt_pos]
+    };
+
+    let reading = if let (Some(s), Some(e)) = (lower.find("<rt>"), lower.find("</rt>")) {
+        &inner[s + 4..e]
+    } else {
+        ""
+    };
+
+    if reading.is_empty() || base.is_empty() {
+        inner.to_string()
+    } else {
+        format!("{}({})", base, reading)
+    }
+}
+
+fn strip_tags_to_newlines(s: &str) -> String {
+    // <br*>, <div*>, <p*> (opening) -> \n; everything else stripped
+    let mut result = String::new();
+    let chars: Vec<char> = s.chars().collect();
+    let mut i = 0;
+    while i < chars.len() {
+        if chars[i] == '<' {
+            let mut tag = String::new();
+            i += 1;
+            while i < chars.len() && chars[i] != '>' {
+                tag.push(chars[i]);
+                i += 1;
+            }
+            if i < chars.len() {
+                i += 1; // skip '>'
+            }
+            let tl = tag.trim_start_matches('/').trim().to_lowercase();
+            let name = tl.split_whitespace().next().unwrap_or("");
+            if matches!(name, "br" | "div" | "p") {
+                result.push('\n');
+            }
+        } else {
+            result.push(chars[i]);
+            i += 1;
+        }
+    }
+    result
+}
+
+fn decode_html_entities(s: &str) -> String {
+    s.replace("&amp;", "&")
+        .replace("&lt;", "<")
+        .replace("&gt;", ">")
+        .replace("&quot;", "\"")
+        .replace("&#39;", "'")
+        .replace("&apos;", "'")
+        .replace("&nbsp;", " ")
+}
+
+pub fn clean_field(raw: &str) -> String {
+    let s = remove_sound_markers(raw);
+    let s = convert_html_ruby(&s);
+    let s = strip_tags_to_newlines(&s);
+    let s = decode_html_entities(&s);
+    // Collapse runs of 3+ newlines to 2
+    let mut s = s;
+    while s.contains("\n\n\n") {
+        s = s.replace("\n\n\n", "\n\n");
+    }
+    s.trim().to_string()
+}
+
+// -- Furigana conversion
+
+fn is_kanji_char(c: char) -> bool {
+    matches!(c, '\u{4E00}'..='\u{9FFF}' | '\u{3400}'..='\u{4DBF}' | '\u{20000}'..='\u{2A6DF}')
+}
+
+// Detect Anki's kanji[reading] syntax in a cleaned string.
+fn has_anki_ruby(s: &str) -> bool {
+    let chars: Vec<char> = s.chars().collect();
+    for i in 0..chars.len().saturating_sub(1) {
+        if is_kanji_char(chars[i]) && chars[i + 1] == '[' {
+            return true;
+        }
+    }
+    false
+}
+
+// Detect our inline (reading) syntax.
+fn has_inline_ruby(s: &str) -> bool {
+    let chars: Vec<char> = s.chars().collect();
+    for i in 0..chars.len().saturating_sub(1) {
+        if is_kanji_char(chars[i]) && chars[i + 1] == '(' {
+            return true;
+        }
+    }
+    false
+}
+
+fn has_ruby_syntax(s: &str) -> bool {
+    has_anki_ruby(s) || has_inline_ruby(s)
+}
+
+// Convert Anki's `kanji[reading]` notation to our `kanji(reading)` notation.
+// Also collapses the separator space Anki puts between groups when the next
+// group starts with a kanji.
+pub fn anki_furigana_to_inline(s: &str) -> String {
+    let chars: Vec<char> = s.chars().collect();
+    let mut result = String::new();
+    let mut i = 0;
+
+    while i < chars.len() {
+        let c = chars[i];
+        if is_kanji_char(c) {
+            // Accumulate kanji run
+            let mut kanji = String::new();
+            kanji.push(c);
+            i += 1;
+            while i < chars.len() && is_kanji_char(chars[i]) {
+                kanji.push(chars[i]);
+                i += 1;
+            }
+            // Check for [reading]
+            if i < chars.len() && chars[i] == '[' {
+                let mut reading = String::new();
+                i += 1; // skip '['
+                while i < chars.len() && chars[i] != ']' && chars[i] != '\n' {
+                    reading.push(chars[i]);
+                    i += 1;
+                }
+                if i < chars.len() && chars[i] == ']' {
+                    i += 1; // skip ']'
+                }
+                result.push_str(&kanji);
+                result.push('(');
+                result.push_str(&reading);
+                result.push(')');
+                // Collapse the separator space between ] and the next kanji
+                if i < chars.len() && chars[i] == ' ' {
+                    let next_cjk = chars[i + 1..]
+                        .iter()
+                        .find(|&&pc| pc != ' ')
+                        .map(|&pc| is_kanji_char(pc))
+                        .unwrap_or(false);
+                    if next_cjk {
+                        i += 1; // skip separator space
+                    }
+                }
+            } else {
+                result.push_str(&kanji);
+            }
+        } else {
+            result.push(c);
+            i += 1;
+        }
+    }
+    result
+}
+
+// -- Field guessing
+
+const JP_HINTS: &[&str] = &[
+    "Expression",
+    "Sentence",
+    "Japanese",
+    "Front",
+    "Word",
+    "Text",
+];
+const TL_HINTS: &[&str] = &["Meaning", "Translation", "English", "Definition", "Back"];
+const FU_HINTS: &[&str] = &["Reading", "Furigana"];
+const SRC_HINTS: &[&str] = &["Source", "Notes", "Deck"];
+
+fn guess_field(fields: &[String], hints: &[&str]) -> Option<String> {
+    for hint in hints {
+        if let Some(f) = fields
+            .iter()
+            .find(|f| f.to_lowercase() == hint.to_lowercase())
+        {
+            return Some(f.clone());
+        }
+    }
+    None
+}
+
+// -- Interactive prompts
+
+fn prompt(question: &str, default: &str) -> String {
+    if default.is_empty() {
+        print!("{}: ", question);
+    } else {
+        print!("{} [{}]: ", question, default);
+    }
+    io::stdout().flush().unwrap();
+    let mut line = String::new();
+    io::stdin().lock().read_line(&mut line).unwrap();
+    let line = line.trim().to_string();
+    if line.is_empty() && !default.is_empty() {
+        default.to_string()
+    } else {
+        line
+    }
+}
+
+fn prompt_field(
+    label: &str,
+    field_names: &[String],
+    hint: Option<&str>,
+    required: bool,
+) -> Result<Option<String>> {
+    let default = hint.unwrap_or("");
+    let suffix = if required { "" } else { " (or skip)" };
+    let input = prompt(&format!("Choose field for {}{}", label, suffix), default);
+
+    if input.is_empty() {
+        if required {
+            return Err(format!("A field for '{label}' is required").into());
+        }
+        return Ok(None);
+    }
+    if !field_names.contains(&input) {
+        return Err(format!("Unknown field: {input}").into());
+    }
+    Ok(Some(input))
+}
+
+// -- Field mapping
+
+struct FieldMapping {
+    japanese: String,
+    translation: Option<String>,
+    furigana: Option<String>,
+    source: Option<String>,
+    deck_name: String,
+}
+
+fn get_field_mapping(
+    field_names: &[String],
+    sample: &AnkiNote,
+    deck: &str,
+    args: &AnkiArgs,
+) -> Result<FieldMapping> {
+    let jp_hint = args
+        .japanese_field
+        .clone()
+        .or_else(|| guess_field(field_names, JP_HINTS));
+    let tl_hint = args
+        .translation_field
+        .clone()
+        .or_else(|| guess_field(field_names, TL_HINTS));
+    let fu_hint = args
+        .furigana_field
+        .clone()
+        .or_else(|| guess_field(field_names, FU_HINTS));
+    let src_hint = args
+        .source_field
+        .clone()
+        .or_else(|| guess_field(field_names, SRC_HINTS));
+
+    if args.yes {
+        let japanese =
+            jp_hint.ok_or("Cannot determine japanese field automatically; use --japanese-field")?;
+        return Ok(FieldMapping {
+            japanese,
+            translation: tl_hint,
+            furigana: fu_hint,
+            source: src_hint,
+            deck_name: deck.to_string(),
+        });
+    }
+
+    // Show sample note fields
+    println!("\nDeck \"{}\" - sample note fields:", deck);
+    for name in field_names {
+        let raw = sample.fields.get(name).map(|s| s.as_str()).unwrap_or("");
+        let clean = clean_field(raw);
+        let preview: String = clean.chars().take(40).collect();
+        let preview = if clean.len() > preview.len() {
+            format!("{}…", preview)
+        } else {
+            preview
+        };
+        println!("  {:<22} - {}", name, preview);
+    }
+    println!();
+
+    let japanese = prompt_field("japanese", field_names, jp_hint.as_deref(), true)?.unwrap();
+    let translation = prompt_field("translation", field_names, tl_hint.as_deref(), false)?;
+    let furigana = prompt_field("furigana", field_names, fu_hint.as_deref(), false)?;
+    let source = prompt_field("source", field_names, src_hint.as_deref(), false)?;
+
+    Ok(FieldMapping {
+        japanese,
+        translation,
+        furigana,
+        source,
+        deck_name: deck.to_string(),
+    })
+}
+
+// -- Note conversion
+
+struct ImportedQuote {
+    japanese: String,
+    translation: Option<String>,
+    source: Option<String>,
+}
+
+fn convert_note(note: &AnkiNote, mapping: &FieldMapping) -> Option<ImportedQuote> {
+    let raw_jp = note.fields.get(&mapping.japanese)?;
+    let mut japanese = clean_field(raw_jp);
+
+    // If no ruby in the japanese field, check the dedicated furigana field
+    if !has_ruby_syntax(&japanese)
+        && let Some(fu_field) = &mapping.furigana
+        && let Some(raw_fu) = note.fields.get(fu_field)
+    {
+        let fu = clean_field(raw_fu);
+        if has_ruby_syntax(&fu) {
+            japanese = fu;
+        }
+    }
+
+    // Convert Anki's bracket notation to our inline parenthesis notation
+    japanese = anki_furigana_to_inline(&japanese);
+
+    if japanese.is_empty() {
+        return None;
+    }
+
+    let translation = mapping
+        .translation
+        .as_ref()
+        .and_then(|f| note.fields.get(f))
+        .map(|v| clean_field(v))
+        .filter(|s| !s.is_empty());
+
+    let source = mapping
+        .source
+        .as_ref()
+        .and_then(|f| note.fields.get(f))
+        .map(|v| clean_field(v))
+        .filter(|s| !s.is_empty())
+        .or_else(|| Some(mapping.deck_name.clone()));
+
+    Some(ImportedQuote {
+        japanese,
+        translation,
+        source,
+    })
+}
+
+// -- TOML output
+
+fn toml_escape(s: &str) -> String {
+    s.replace('\\', "\\\\")
+        .replace('"', "\\\"")
+        .replace('\n', "\\n")
+        .replace('\r', "")
+        .replace('\t', "\\t")
+}
+
+fn write_quotes_toml(path: &PathBuf, quotes: &[ImportedQuote]) -> std::io::Result<()> {
+    let mut content = String::new();
+    for q in quotes {
+        content.push_str("[[quote]]\n");
+        content.push_str(&format!("japanese = \"{}\"\n", toml_escape(&q.japanese)));
+        if let Some(t) = &q.translation {
+            content.push_str(&format!("translation = \"{}\"\n", toml_escape(t)));
+        }
+        if let Some(s) = &q.source {
+            content.push_str(&format!("source = \"{}\"\n", toml_escape(s)));
+        }
+        content.push('\n');
+    }
+    fs::write(path, content)
+}
+
+// -- Deck selection
+
+fn sanitize_deck_name(name: &str) -> String {
+    name.chars()
+        .map(|c| match c {
+            'a'..='z' | '0'..='9' => c,
+            'A'..='Z' => c.to_ascii_lowercase(),
+            ' ' | ':' | '_' => '-',
+            _ => '-',
+        })
+        .collect::<String>()
+        // collapse multiple dashes
+        .split('-')
+        .filter(|s| !s.is_empty())
+        .collect::<Vec<_>>()
+        .join("-")
+}
+
+fn select_decks(decks: &[String], args: &AnkiArgs) -> Result<Vec<String>> {
+    if !args.deck.is_empty() {
+        for d in &args.deck {
+            if !decks.contains(d) {
+                return Err(
+                    format!("Deck not found: \"{d}\"\nAvailable: {}", decks.join(", ")).into(),
+                );
+            }
+        }
+        return Ok(args.deck.clone());
+    }
+
+    let mut sorted = decks.to_vec();
+    sorted.sort();
+    println!("Found {} decks:", sorted.len());
+    for (i, d) in sorted.iter().enumerate() {
+        println!("  [{i}] {d}");
+    }
+
+    let input = prompt("Select decks (comma-separated indices, or 'all')", "0");
+
+    if input.trim() == "all" {
+        return Ok(sorted);
+    }
+
+    let mut selected = Vec::new();
+    for part in input.split(',') {
+        let idx: usize = part
+            .trim()
+            .parse()
+            .map_err(|_| format!("Invalid index: \"{}\"", part.trim()))?;
+        if idx >= sorted.len() {
+            return Err(format!("Index {idx} is out of range (0–{})", sorted.len() - 1).into());
+        }
+        selected.push(sorted[idx].clone());
+    }
+    Ok(selected)
+}
+
+// -- Entry point
+
+pub fn run_init(args: &AnkiArgs) -> Result<()> {
+    println!("Connecting to AnkiConnect at {} ...", args.url);
+    let client = AnkiClient::new(&args.url);
+
+    let all_decks = client.deck_names()?;
+    let selected = select_decks(&all_decks, args)?;
+
+    let out_dir = if let Some(d) = &args.output_dir {
+        d.clone()
+    } else {
+        let mut p = config_dir().ok_or("could not determine config directory")?;
+        p.push("kotofetch/quotes");
+        p
+    };
+    fs::create_dir_all(&out_dir)?;
+
+    for deck in &selected {
+        let note_ids = client.find_notes(deck)?;
+        if note_ids.is_empty() {
+            println!("Deck \"{deck}\" is empty, skipping.");
+            continue;
+        }
+
+        // Fetch a single note to show sample fields
+        let sample_batch = client.notes_info(&note_ids[..1])?;
+        let sample = match sample_batch.first() {
+            Some(n) => n,
+            None => {
+                println!("Deck \"{deck}\" returned no notes, skipping.");
+                continue;
+            }
+        };
+
+        let mapping = get_field_mapping(&sample.field_order, sample, deck, args)?;
+
+        // Fetch all notes
+        let notes = client.notes_info(&note_ids)?;
+
+        let mut quotes = Vec::new();
+        let mut skipped = 0usize;
+        for note in &notes {
+            match convert_note(note, &mapping) {
+                Some(q) => quotes.push(q),
+                None => skipped += 1,
+            }
+        }
+
+        let filename = sanitize_deck_name(deck) + ".toml";
+        let out_path = out_dir.join(&filename);
+
+        if out_path.exists() && !args.yes {
+            let answer = prompt(
+                &format!("{} already exists. Overwrite? (y/n)", out_path.display()),
+                "y",
+            );
+            if !answer.starts_with('y') && !answer.starts_with('Y') {
+                println!("Skipping \"{deck}\".");
+                continue;
+            }
+        }
+
+        println!(
+            "Importing {} notes from \"{}\" -> {}",
+            quotes.len(),
+            deck,
+            out_path.display()
+        );
+        if skipped > 0 {
+            println!("  (skipped {skipped} notes with empty japanese field)");
+        }
+        write_quotes_toml(&out_path, &quotes)?;
+    }
+
+    if selected.len() == 1 {
+        let mode = sanitize_deck_name(&selected[0]);
+        println!("\nDone. Run: kotofetch --modes {mode}");
+    } else {
+        println!("\nDone.");
+    }
+
+    Ok(())
+}

--- a/src/anki.rs
+++ b/src/anki.rs
@@ -30,8 +30,9 @@ impl AnkiClient {
         let response = ureq::post(&self.url)
             .send_json(body)
             .map_err(|e| format!("Could not reach AnkiConnect at {}: {e}", self.url))?;
-        let json: Value = response
-            .into_json()
+        let mut resp_body = response.into_body();
+        let json: Value = resp_body
+            .read_json()
             .map_err(|e| format!("Failed to parse AnkiConnect response: {e}"))?;
 
         if let Some(err) = json["error"].as_str().filter(|s| !s.is_empty()) {
@@ -352,6 +353,7 @@ const JP_HINTS: &[&str] = &[
 ];
 const TL_HINTS: &[&str] = &["Meaning", "Translation", "English", "Definition", "Back"];
 const FU_HINTS: &[&str] = &["Reading", "Furigana"];
+const RO_HINTS: &[&str] = &["Romaji", "Romanization", "Romaji Reading"];
 const SRC_HINTS: &[&str] = &["Source", "Notes", "Deck"];
 
 fn guess_field(fields: &[String], hints: &[&str]) -> Option<String> {
@@ -413,13 +415,37 @@ struct FieldMapping {
     japanese: String,
     translation: Option<String>,
     furigana: Option<String>,
+    romaji: Option<String>,
     source: Option<String>,
     deck_name: String,
 }
 
+fn print_sample(samples: &[AnkiNote], idx: usize, deck: &str) {
+    let sample = &samples[idx];
+    let field_names = &sample.field_order;
+    println!(
+        "\nDeck \"{}\" - sample note ({}/{}):",
+        deck,
+        idx + 1,
+        samples.len()
+    );
+    for name in field_names {
+        let raw = sample.fields.get(name).map(|s| s.as_str()).unwrap_or("");
+        let clean = clean_field(raw);
+        let preview: String = clean.chars().take(40).collect();
+        let preview = if clean.len() > preview.len() {
+            format!("{}...", preview)
+        } else {
+            preview
+        };
+        println!("  {:<22} - {}", name, preview);
+    }
+    println!();
+}
+
 fn get_field_mapping(
     field_names: &[String],
-    sample: &AnkiNote,
+    samples: &[AnkiNote],
     deck: &str,
     args: &AnkiArgs,
 ) -> Result<FieldMapping> {
@@ -435,6 +461,10 @@ fn get_field_mapping(
         .furigana_field
         .clone()
         .or_else(|| guess_field(field_names, FU_HINTS));
+    let ro_hint = args
+        .romaji_field
+        .clone()
+        .or_else(|| guess_field(field_names, RO_HINTS));
     let src_hint = args
         .source_field
         .clone()
@@ -447,35 +477,40 @@ fn get_field_mapping(
             japanese,
             translation: tl_hint,
             furigana: fu_hint,
+            romaji: ro_hint,
             source: src_hint,
             deck_name: deck.to_string(),
         });
     }
 
-    // Show sample note fields
-    println!("\nDeck \"{}\" - sample note fields:", deck);
-    for name in field_names {
-        let raw = sample.fields.get(name).map(|s| s.as_str()).unwrap_or("");
-        let clean = clean_field(raw);
-        let preview: String = clean.chars().take(40).collect();
-        let preview = if clean.len() > preview.len() {
-            format!("{}…", preview)
-        } else {
-            preview
-        };
-        println!("  {:<22} - {}", name, preview);
+    // Show sample note, let user cycle through samples if needed
+    let mut idx = 0;
+    loop {
+        print_sample(samples, idx, deck);
+        if samples.len() > 1 {
+            let input = prompt(
+                "Press Enter to map fields, or type 'next' for another sample",
+                "",
+            );
+            if input.trim().eq_ignore_ascii_case("next") {
+                idx = (idx + 1) % samples.len();
+                continue;
+            }
+        }
+        break;
     }
-    println!();
 
     let japanese = prompt_field("japanese", field_names, jp_hint.as_deref(), true)?.unwrap();
     let translation = prompt_field("translation", field_names, tl_hint.as_deref(), false)?;
     let furigana = prompt_field("furigana", field_names, fu_hint.as_deref(), false)?;
+    let romaji = prompt_field("romaji", field_names, ro_hint.as_deref(), false)?;
     let source = prompt_field("source", field_names, src_hint.as_deref(), false)?;
 
     Ok(FieldMapping {
         japanese,
         translation,
         furigana,
+        romaji,
         source,
         deck_name: deck.to_string(),
     })
@@ -486,6 +521,7 @@ fn get_field_mapping(
 struct ImportedQuote {
     japanese: String,
     translation: Option<String>,
+    romaji: Option<String>,
     source: Option<String>,
 }
 
@@ -518,6 +554,13 @@ fn convert_note(note: &AnkiNote, mapping: &FieldMapping) -> Option<ImportedQuote
         .map(|v| clean_field(v))
         .filter(|s| !s.is_empty());
 
+    let romaji = mapping
+        .romaji
+        .as_ref()
+        .and_then(|f| note.fields.get(f))
+        .map(|v| clean_field(v))
+        .filter(|s| !s.is_empty());
+
     let source = mapping
         .source
         .as_ref()
@@ -529,6 +572,7 @@ fn convert_note(note: &AnkiNote, mapping: &FieldMapping) -> Option<ImportedQuote
     Some(ImportedQuote {
         japanese,
         translation,
+        romaji,
         source,
     })
 }
@@ -550,6 +594,9 @@ fn write_quotes_toml(path: &PathBuf, quotes: &[ImportedQuote]) -> std::io::Resul
         content.push_str(&format!("japanese = \"{}\"\n", toml_escape(&q.japanese)));
         if let Some(t) = &q.translation {
             content.push_str(&format!("translation = \"{}\"\n", toml_escape(t)));
+        }
+        if let Some(r) = &q.romaji {
+            content.push_str(&format!("romaji = \"{}\"\n", toml_escape(r)));
         }
         if let Some(s) = &q.source {
             content.push_str(&format!("source = \"{}\"\n", toml_escape(s)));
@@ -641,17 +688,16 @@ pub fn run_init(args: &AnkiArgs) -> Result<()> {
             continue;
         }
 
-        // Fetch a single note to show sample fields
-        let sample_batch = client.notes_info(&note_ids[..1])?;
-        let sample = match sample_batch.first() {
-            Some(n) => n,
-            None => {
-                println!("Deck \"{deck}\" returned no notes, skipping.");
-                continue;
-            }
-        };
+        // Fetch a small batch of notes to use as samples
+        let sample_count = note_ids.len().min(10);
+        let samples = client.notes_info(&note_ids[..sample_count])?;
+        if samples.is_empty() {
+            println!("Deck \"{deck}\" returned no notes, skipping.");
+            continue;
+        }
+        let field_names = samples[0].field_order.clone();
 
-        let mapping = get_field_mapping(&sample.field_order, sample, deck, args)?;
+        let mapping = get_field_mapping(&field_names, &samples, deck, args)?;
 
         // Fetch all notes
         let notes = client.notes_info(&note_ids)?;

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,9 +1,12 @@
-use clap::{Parser, ValueEnum};
+use clap::{Args, Parser, Subcommand, ValueEnum};
 use std::path::PathBuf;
 
 #[derive(Parser, Debug)]
 #[command(author, version, about)]
 pub struct Cli {
+    #[command(subcommand)]
+    pub command: Option<Commands>,
+
     // Path to config file (TOML). Defaults to ~/.config/kotofetch/config.toml
     #[arg(short, long)]
     pub config: Option<PathBuf>,
@@ -71,6 +74,56 @@ pub struct Cli {
     // Dynamic re-centering text
     #[arg(long)]
     pub dynamic: Option<bool>,
+}
+
+#[derive(Subcommand, Debug)]
+pub enum Commands {
+    // Import quotes from external sources
+    Init {
+        #[command(subcommand)]
+        source: InitSource,
+    },
+}
+
+#[derive(Subcommand, Debug)]
+pub enum InitSource {
+    // Import Anki decks via AnkiConnect
+    Anki(AnkiArgs),
+}
+
+#[derive(Args, Debug)]
+pub struct AnkiArgs {
+    // AnkiConnect URL
+    #[arg(long, default_value = "http://localhost:8765")]
+    pub url: String,
+
+    // Deck name(s) to import (repeatable; skips interactive deck picker)
+    #[arg(long)]
+    pub deck: Vec<String>,
+
+    // Field to use as the Japanese text
+    #[arg(long)]
+    pub japanese_field: Option<String>,
+
+    // Field to use as the English translation
+    #[arg(long)]
+    pub translation_field: Option<String>,
+
+    // Field containing Anki furigana markup (used if japanese field has none)
+    #[arg(long)]
+    pub furigana_field: Option<String>,
+
+    // Field to use as the source label
+    #[arg(long)]
+    pub source_field: Option<String>,
+
+    // Output directory (default: ~/.config/kotofetch/quotes/)
+    #[arg(long)]
+    pub output_dir: Option<PathBuf>,
+
+    // Skip all prompts; use heuristic field mapping and overwrite existing files
+    #[arg(long, default_value_t = false)]
+    pub yes: bool,
 }
 
 #[derive(ValueEnum, Clone, Debug, PartialEq, Eq)]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -113,6 +113,10 @@ pub struct AnkiArgs {
     #[arg(long)]
     pub furigana_field: Option<String>,
 
+    // Field to use as the romaji (romanized) reading
+    #[arg(long)]
+    pub romaji_field: Option<String>,
+
     // Field to use as the source label
     #[arg(long)]
     pub source_field: Option<String>,

--- a/src/display.rs
+++ b/src/display.rs
@@ -77,7 +77,7 @@ fn parse_ruby(s: &str) -> Vec<Segment> {
                     break;
                 }
                 if rc == '\n' {
-                    // Newline terminates an unclosed paren — treat as plain
+                    // Newline terminates an unclosed paren - treat as plain
                     reading.push(rc);
                     break;
                 }
@@ -493,7 +493,7 @@ fn print_boxed(
                 .enumerate()
                 .map(|(i, wline)| {
                     if i == 0 {
-                        format!("— {}", wline)
+                        format!("- {}", wline)
                     } else {
                         format!("  {}", wline)
                     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,20 +1,28 @@
+mod anki;
 mod cli;
 mod config;
 mod display;
 mod quotes;
 
-use crate::cli::Cli;
+use crate::cli::{Cli, Commands, InitSource};
 use clap::Parser;
 
 fn main() {
     let cli = Cli::parse();
 
-    // load user config (if exists)
-    let user_cfg = config::load_user_config(cli.config.clone());
-
-    // merge into a runtime Config
-    let runtime = config::make_runtime_config(user_cfg, &cli);
-
-    // render output
-    display::render(&runtime, &cli);
+    match &cli.command {
+        Some(Commands::Init {
+            source: InitSource::Anki(args),
+        }) => {
+            if let Err(e) = anki::run_init(args) {
+                eprintln!("Error: {e}");
+                std::process::exit(1);
+            }
+        }
+        None => {
+            let user_cfg = config::load_user_config(cli.config.clone());
+            let runtime = config::make_runtime_config(user_cfg, &cli);
+            display::render(&runtime, &cli);
+        }
+    }
 }


### PR DESCRIPTION
Adds `kotofetch init anki`, a quick way to pull your Anki decks into kotofetch without manually writing TOML files.

If you have Anki running with the AnkiConnect plugin, it'll connect, show you your decks, let you pick one (or several), and walk you through mapping note fields to japanese/translation/furigana/romaji. The output lands in ~/.config/kotofetch/quotes/<deck-name>.toml and is immediately usable with --modes.

Furigana works out of the box: Anki's 食[た]べる bracket syntax gets converted to kotofetch's inline 食(た)べる format on import, so --translation furigana just works. HTML and sound markers are stripped during import too.

A few things I ran into while building this that are worth mentioning:
- The first note in a deck is sometimes a metadata/info card with no real content, so you can now type next during field mapping to cycle through up to 10 sample notes until you find one that's representative.
- Non-interactive mode is fully supported via flags (--deck, --japanese-field, etc. + --yes) for scripting.