### PR TITLE
feat: Shell autocompletion

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -114,6 +114,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap_complete"
+version = "4.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "660c0520455b1013b9bcb0393d5f643d7e4454fb69c915b8d6d2aa0e9a45acc3"
+dependencies = [
+ "clap",
+]
+
+[[package]]
 name = "clap_derive"
 version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -453,6 +462,7 @@ name = "kotofetch"
 version = "0.2.21"
 dependencies = [
  "clap",
+ "clap_complete",
  "console",
  "ctrlc",
  "dirs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ license = "MIT"
 
 [dependencies]
 clap = { version = "4.5.47", features = ["derive"] }
+clap_complete = { version = "4.6.3" }
 console = "0.16.1"
 ctrlc = "3.5.0"
 dirs = "6.0.0"

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@
   - [Custom quotes](#custom-quotes)
 - [Usage](#usage)
   - [Translation Modes](#translation-modes)
+- [Autocompletion](#autocompletion)
 - [Community Showcase](#community-showcase)
 - [Contributing](#contributing)
 
@@ -241,6 +242,15 @@ Multiple modes can be combined by passing a comma-separated list: `--translation
 
 Furigana displays readings aligned with their kanji, supporting both single-kanji annotations (`知(し)`) and compound words (`大海(たいかい)`). Only quotes that include inline ruby markup in their `japanese` field will show furigana readings. Use `--furigana-position above` (or `furigana_position = "above"` in config) to render readings above the Japanese text instead of below.
 
+## Autocompletion
+
+You can get the script by running this command:
+```bash
+kotofetch completion <SHELL>
+```
+The setup depends on the specific shell.
+
+The supported shells are those supported by the currently used `clap_complete` version.
 
 ## Community Showcase
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,4 +1,5 @@
 use clap::{Args, Parser, Subcommand, ValueEnum};
+use clap_complete::Shell;
 use std::path::PathBuf;
 
 #[derive(Parser, Debug)]
@@ -86,6 +87,11 @@ pub enum Commands {
     Init {
         #[command(subcommand)]
         source: InitSource,
+    },
+    /// Output the completion script
+    Completion {
+        /// Select the shell
+        shell: Shell,
     },
 }
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -3,7 +3,7 @@ use clap_complete::Shell;
 use std::path::PathBuf;
 
 #[derive(Parser, Debug)]
-#[command(author, version, about)]
+#[command(name = "kotofetch", author, version, about)]
 pub struct Cli {
     #[command(subcommand)]
     pub command: Option<Commands>,

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,7 +5,9 @@ mod display;
 mod quotes;
 
 use crate::cli::{Cli, Commands, InitSource};
-use clap::Parser;
+use clap::{CommandFactory, Parser};
+use clap_complete::generate;
+use std::io;
 
 fn main() {
     let cli = Cli::parse();
@@ -18,6 +20,11 @@ fn main() {
                 eprintln!("Error: {e}");
                 std::process::exit(1);
             }
+        }
+        Some(Commands::Completion { shell }) => {
+            let mut cmd = Cli::command();
+            let cmdname = cmd.get_name().to_string();
+            generate(*shell, &mut cmd, cmdname, &mut io::stdout());
         }
         None => {
             let user_cfg = config::load_user_config(cli.config.clone());


### PR DESCRIPTION
Add `clap_complete` version `4.6.3`.

Add subcommand `completion <SHELL>`. Which prints the completion script to stdout.

Update README to have a section for autocompletion.

Closes #27 